### PR TITLE
Refactor/syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Liquid Schema Plugin
 
-This plugin allows Shopify section schema to be imported from JavaScript or JSON files into Liquid sections. It is compatible with any Webpack based build system. This allows you to build partials that can be shared across multiple sections and applied in different contexts such as section blocks or settings.
+This plugin allows Shopify section schema to be imported from JavaScript files into Liquid sections. It is compatible with any Webpack based build system. This allows you to build partials that can be shared across multiple sections and applied in different contexts such as section blocks or settings.
 
 ## Installation
 Install using yarn:
@@ -11,28 +11,6 @@ yarn add --dev liquid-schema-plugin
 Or npm:
 ```shell
 npm install --save-dev liquid-schema-plugin
-```
-
-### Slate v1
-
-Add the plugin to `slate.config.js`
-```js
-const LiquidSchemaPlugin = require('liquid-schema-plugin');
-
-module.exports = {
-  // ...
-  'webpack.extend': {
-    plugins: [
-      new LiquidSchemaPlugin({
-        from: {
-          liquid: './src/sections',
-          schema: './src/schema'
-        },
-        to: './dist/sections'
-      })
-    ]
-  }
-}
 ```
 
 ### Webpack
@@ -58,12 +36,9 @@ module.exports = {
 
 ## Usage
 
-Add the following to a section file, where `'filepath'` is the location of the schema relative to the `schemaDirectory` defined in the plugin settings:
-```liquid
-// section.liquid
-{% schema 'filepath' %}
-```
-Note: It doesn't require an `endschema` tag.
+This plugin will attempt to find and compile schema for any Liquid section source file that does not already contain `{% schema %}` and `{% endschema %}` tags in its contents.
+
+The schema JS files rely on a consistent naming convention to be paired with the Shopify section files. The JS file path is prefixed with `section-`. For example, `hero-banner.liquid` in the Liquid source directory would be paired with `section-hero-banner.js` in the schema directory.
 
 ```js
 // schema.js
@@ -73,27 +48,6 @@ module.exports = {
   name: 'Section',
   blocks: [banner]
 }
-```
-
-Alternatively, the schema file can export a function, in which case it takes the section filename as the first argument and the contents of the schema tags (after running it through JSON.parse) as the second, like so:
-```liquid
-// section.liquid
-{% schema 'filepath' %}
-{
-  "settings": [...]
-}
-{% endschema %}
-```
-
-```js
-// schema.js
-const banner = require('./components/banner')
-
-module.exports = (filename, contents) => ({
-  name: filename,
-  settings: contents.settings,
-  blocks: [banner]
-})
 ```
 
 ## Further Reading

--- a/plugin/index.js
+++ b/plugin/index.js
@@ -136,10 +136,13 @@ module.exports = class LiquidSchemaPlugin {
       ].join('\n');
     }
 
-    const comment = `{% comment %} Schema compiled by Liquid Schema Plugin from ${this.options.from.schema}${path.sep}${importableFileName} {% endcomment %}`;
+    const comment = `{% comment %} Schema compiled by Liquid Schema Plugin from ${this.options.from.schema.replace(
+      path.sep,
+      '/'
+    )}/${importableFileName} {% endcomment %}`;
     const commentRegex = new RegExp(comment, 'i');
 
-    if (!commentRegex.test(fileLocation)) {
+    if (!commentRegex.test(fileContents)) {
       fs.appendFileSync(fileLocation, `\n${comment}\n`);
     }
 

--- a/plugin/index.js
+++ b/plugin/index.js
@@ -98,11 +98,10 @@ module.exports = class LiquidSchemaPlugin {
       return new RawSource(fileContents);
     }
 
-    let importableFilePath = `section-${fileName}.js`;
-    importableFilePath = importableFilePath.replace(/(^('|"))|(('|")$)/g, '');
-    importableFilePath = path.resolve(
+    const importableFileName = `section-${fileName}.js`;
+    const importableFilePath = path.resolve(
       this.options.from.schema,
-      importableFilePath
+      importableFileName
     );
 
     if (!fs.existsSync(importableFilePath)) {
@@ -137,7 +136,14 @@ module.exports = class LiquidSchemaPlugin {
       ].join('\n');
     }
 
-    const fileContentsWithSchema = `${fileContents}\n\n{% schema %}\n${JSON.stringify(
+    const comment = `{% comment %} Schema compiled by Liquid Schema Plugin from ${this.options.from.schema}${path.sep}${importableFileName} {% endcomment %}`;
+    const commentRegex = new RegExp(comment, 'i');
+
+    if (!commentRegex.test(fileLocation)) {
+      fs.appendFileSync(fileLocation, `\n${comment}\n`);
+    }
+
+    const fileContentsWithSchema = `${fileContents}\n{% schema %}\n${JSON.stringify(
       schema,
       null,
       2

--- a/plugin/index.js
+++ b/plugin/index.js
@@ -18,10 +18,7 @@ module.exports = class LiquidSchemaPlugin {
     const isWebpack4 = !compiler.webpack;
 
     if (isWebpack4) {
-      compiler.hooks.emit.tapPromise(
-        PLUGIN_NAME,
-        this.buildSchema.bind(this)
-      );
+      compiler.hooks.emit.tapPromise(PLUGIN_NAME, this.buildSchema.bind(this));
 
       return;
     }
@@ -45,10 +42,7 @@ module.exports = class LiquidSchemaPlugin {
 
     return Promise.all(
       files.map(async file => {
-        const fileLocation = path.resolve(
-          this.options.from.liquid,
-          file
-        );
+        const fileLocation = path.resolve(this.options.from.liquid, file);
         const fileStat = await fs.stat(fileLocation);
 
         if (fileStat.isFile() && path.extname(file) === '.liquid') {
@@ -57,16 +51,11 @@ module.exports = class LiquidSchemaPlugin {
             fileLocation
           );
 
-          const outputKey = this.getOutputKey(
-            fileLocation,
-            compilationOutput
-          );
+          const outputKey = this.getOutputKey(fileLocation, compilationOutput);
 
           try {
             // eslint-disable-next-line no-param-reassign
-            compilation.assets[
-              outputKey
-            ] = await this.replaceSchemaTags(
+            compilation.assets[outputKey] = await this.replaceSchemaTags(
               fileLocation,
               compilation
             );
@@ -90,10 +79,7 @@ module.exports = class LiquidSchemaPlugin {
   }
 
   getOutputKey(liquidSourcePath, compilationOutput) {
-    const fileName = path.relative(
-      this.options.from.liquid,
-      liquidSourcePath
-    );
+    const fileName = path.relative(this.options.from.liquid, liquidSourcePath);
     const relativeOutputPath = path.relative(
       compilationOutput,
       this.options.to
@@ -118,10 +104,7 @@ module.exports = class LiquidSchemaPlugin {
     let [match, importableFilePath, , contents] = fileContents.match(
       replaceableSchemaRegex
     );
-    importableFilePath = importableFilePath.replace(
-      /(^('|"))|(('|")$)/g,
-      ''
-    );
+    importableFilePath = importableFilePath.replace(/(^('|"))|(('|")$)/g, '');
     importableFilePath = path.resolve(
       this.options.from.schema,
       importableFilePath

--- a/plugin/index.js
+++ b/plugin/index.js
@@ -136,22 +136,27 @@ module.exports = class LiquidSchemaPlugin {
       ].join('\n');
     }
 
-    const comment = `{% comment %} Schema compiled by Liquid Schema Plugin from ${this.options.from.schema.replace(
-      path.sep,
-      '/'
-    )}/${importableFileName} {% endcomment %}`;
+    const relativePathString = `./${path.relative(
+      path.resolve(process.cwd()),
+      path.resolve(__dirname, importableFilePath)
+    )}`;
+    const comment = `{% comment %} Schema compiled by Liquid Schema Plugin from ${relativePathString} {% endcomment %}`;
     const commentRegex = new RegExp(comment, 'i');
+    const hasComment = commentRegex.test(fileContents);
 
-    if (!commentRegex.test(fileContents)) {
+    if (!hasComment) {
       fs.appendFileSync(fileLocation, `\n${comment}\n`);
     }
 
-    const fileContentsWithSchema = `${fileContents}\n{% schema %}\n${JSON.stringify(
+    const schemaString = `{% schema %}\n${JSON.stringify(
       schema,
       null,
       2
     )}\n{% endschema %}`;
 
+    const fileContentsWithSchema = hasComment
+      ? `${fileContents}\n${schemaString}`
+      : `${fileContents}\n${comment}\n\n${schemaString}`;
     return new RawSource(fileContentsWithSchema);
   }
 };


### PR DESCRIPTION
## Description

Refactor the plugin's syntax check, which previously would look for a schema tag formatted like `{% schema 'section-hero-banner' %}`. The Shopify theme check linter flags this custom Liquid tag. Instead, do the following in this order:
- Use regex to check if the Liquid section file already has a schema in the `src` directory.
- If it doesn't, check the specified schema directory for a JS file with a name matching the Liquid section file name in the source folder, e.g. `section-hero-banner.js`.
- If the file doesn't exist, the Liquid section file gets copied over into `dist` as is. If a matching schema JS file does exist, it gets compiled with the schema tags into `dist`.
- A Liquid comment is also added to the source section file to state that the schema lives in the schema source folder.

## Type of Change

*Use an X inside the box to check it off. Remove this line once done.*

- [ ] Bugfix *(non-breaking change which fixes an issue)*
- [ ] Feature/change *(non-breaking feature/change, either as-new, or applied to existing code)*
- [X] Breaking feature/change *(breaking feature/change which causes existing functionality to not work as current)*

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208660377411191